### PR TITLE
Updated settings page

### DIFF
--- a/src/Gir/Cart/Views.fs
+++ b/src/Gir/Cart/Views.fs
@@ -16,14 +16,12 @@ let initCheckoutInstance (settings: Settings) (checkoutFrontendBundleUrl: string
              [ script
                  [ _type "application/javascript"
                    _src "/js/checkout-integration.js" ] []
-               script [ _type "application/javascript"] [
-                  rawText <|
-                    sprintf
-                      """initCheckout("%s", "%s", %b, %b);"""
-                      checkoutFrontendBundleUrl
-                      purchaseToken
-                      settings.ExtraCheckoutFlags.DisableFocus
-                      settings.ExtraCheckoutFlags.CustomStyles ] ])
+               script [ _type "application/javascript" ]
+                   [ rawText
+                     <| sprintf """initCheckout("%s", "%s", %b, %b, %b, %b);""" checkoutFrontendBundleUrl purchaseToken
+                            settings.ExtraCheckoutFlags.DisableFocus settings.ExtraCheckoutFlags.CustomStyles
+                            settings.ExtraCheckoutFlags.BeforeSubmitCallbackEnabled
+                            settings.ExtraCheckoutFlags.DeliveryAddressChangedCallbackEnabled ] ])
 
 let cartItemView (settings: Settings) (cartItem: CartItem) =
     tr []

--- a/src/Gir/Decoders.fs
+++ b/src/Gir/Decoders.fs
@@ -90,9 +90,6 @@ let extraInitSettingsDecoder =
               |> stringToCheckboxState
           EmailNewsletterSubscription =
               (get.Required.Field "emailNewsletterSubscription" Decode.string)
-              |> stringToCheckboxState
-          EmailInvoice =
-              (get.Required.Field "emailInvoice" Decode.string)
               |> stringToCheckboxState })
 
 let decodeSettings =
@@ -101,12 +98,16 @@ let decodeSettings =
           ExtraInitSettings = get.Required.Field "extraInitSettings" extraInitSettingsDecoder
           Market =
               get.Required.Field "market" Decode.string
-              |> stringToMarket })
+              |> stringToMarket
+          OrderReference =
+              (get.Optional.Field "orderReference" Decode.string)
+              |> Option.defaultValue defaultSettings.OrderReference })
 
 let settingsDecoder (s: string) =
     match Decode.fromString decodeSettings s with
     | Ok v ->
         { ExtraCheckoutFlags = v.ExtraCheckoutFlags
           ExtraInitSettings = v.ExtraInitSettings
-          Market = v.Market }
+          Market = v.Market
+          OrderReference = v.OrderReference }
     | Error e -> failwithf "Cannot decode settings, error = %A" e

--- a/src/Gir/Domain.fs
+++ b/src/Gir/Domain.fs
@@ -60,8 +60,7 @@ type ExtraInitSettings =
       DisplayItems: bool
       RecurringPayments: CheckboxState
       SmsNewsletterSubscription: CheckboxState
-      EmailNewsletterSubscription: CheckboxState
-      EmailInvoice: CheckboxState }
+      EmailNewsletterSubscription: CheckboxState }
 
 type ExtraCheckoutFlags =
     { DisableFocus: bool
@@ -76,7 +75,8 @@ type Market =
 type Settings =
     { ExtraCheckoutFlags: ExtraCheckoutFlags
       ExtraInitSettings: ExtraInitSettings
-      Market: Market }
+      Market: Market
+      OrderReference: string }
 
 let languageToString (language: Language) =
     match language with
@@ -161,7 +161,7 @@ let stringToMarket (s: string) =
     | _ -> Sweden
 
 let defaultExtraCheckoutFlags =
-    { DisableFocus = true
+    { DisableFocus = false
       BeforeSubmitCallbackEnabled = false
       DeliveryAddressChangedCallbackEnabled = false
       CustomStyles = false }
@@ -174,10 +174,10 @@ let defaultExtraInitSettings =
       DisplayItems = true
       RecurringPayments = Hidden
       SmsNewsletterSubscription = Hidden
-      EmailNewsletterSubscription = Hidden
-      EmailInvoice = Hidden }
+      EmailNewsletterSubscription = Hidden }
 
 let defaultSettings =
     { ExtraCheckoutFlags = defaultExtraCheckoutFlags
       ExtraInitSettings = defaultExtraInitSettings
-      Market = Sweden }
+      Market = Sweden
+      OrderReference = "TEST-AVARDA-DEMO-SHOP" }

--- a/src/Gir/Settings/HttpHandlers.fs
+++ b/src/Gir/Settings/HttpHandlers.fs
@@ -9,8 +9,9 @@ open Views
 
 
 let settingsHandler (next: HttpFunc) (ctx: HttpContext) =
+    let cartState = Session.getCartState ctx
     let settings = Session.getSettings ctx
-    (htmlView <| settingsView settings) next ctx
+    (htmlView <| settingsView settings cartState) next ctx
 
 let saveSettingsHandler (next: HttpFunc) (ctx: HttpContext) =
     task {
@@ -45,9 +46,9 @@ let saveSettingsHandler (next: HttpFunc) (ctx: HttpContext) =
                         |> stringToCheckboxState
                     EmailNewsletterSubscription =
                         getValue "emailNewsletterSubscription"
-                        |> stringToCheckboxState
-                    EmailInvoice = getValue "emailInvoice" |> stringToCheckboxState }
-              Market = getValue "market" |> stringToMarket }
+                        |> stringToCheckboxState }
+              Market = getValue "market" |> stringToMarket
+              OrderReference = getValue "orderReference" }
 
         Session.setSettings ctx formData
         Session.deleteCartState ctx

--- a/src/Gir/Settings/Views.fs
+++ b/src/Gir/Settings/Views.fs
@@ -10,7 +10,7 @@ let rowStyles =
         "display: flex; flex-direction: row; align-items: center; justify-content: space-between; padding: 0px 50px; height: 50px;"
 
 let columnStyles =
-    _style "display: flex; flex-direction: column; padding: 20px 0px 0px 20px; width: 600px;"
+    _style "display: flex; flex-direction: column; padding: 20px 0px 0px 20px;"
 
 let checkboxView (inputId: string) (inputLabel: string) (isChecked: bool) (isEnabled: bool) =
     let checkedAttribute = if isChecked then [ _checked ] else []
@@ -54,54 +54,112 @@ let selectView
                @ disabledAttribute)
               (List.map (fun o -> option ([ _value o ] @ selectedOptionAttribute o) [ str o ]) selectOptions) ]
 
-let template (settings: Settings) =
+let inputView inputId inputLabel value isEnabled =
+    let disabledAttribute = if isEnabled then [] else [ _disabled ]
+    div [ rowStyles ]
+        [ label [ _for inputId ] [ str inputLabel ]
+          input
+              ([ _type "text"
+                 _style "width: 50%;
+                        height: 50px;
+                        background-color: #fff;
+                        color: #000;
+                        font-size: 14px;
+                        border: 1px solid #e8e8e8;
+                        border-radius: 5px;
+                        padding: 0 10px;"
+                 _id inputId
+                 _name inputId
+                 _value value ]
+               @ disabledAttribute) ]
+
+let template (settings: Settings) (cartState: CartState) =
     let checkboxStateOptions = [ "Hidden"; "Checked"; "Unchecked" ]
 
     let { ExtraInitSettings = initSettings; ExtraCheckoutFlags = checkoutFlags } = settings
 
-    div [ columnStyles ]
-        [ form
-            [ _id "settings"
-              _action "/settings/save"
-              _method "POST" ]
-              [ div [] [ h3 [] [ str "Market" ] ]
-                selectView "market" "Market" [ "Sweden"; "Finland" ] (marketToString settings.Market) true
-                div [] [ h3 [] [ str "Extra Init Options" ] ]
-                selectView "language" "Language"
-                    [ "English"
-                      "Swedish"
-                      "Finnish"
-                      "Norwegian"
-                      "Estonian"
-                      "Danish" ] (languageToString initSettings.Language) true
-                selectView "mode" "Mode" [ "b2c"; "b2b" ] "b2c" false
-                selectView "differentDeliveryAddress" "Different Delivery Address" checkboxStateOptions
-                    (checkboxStateToString initSettings.DifferentDeliveryAddress) false
-                checkboxView "displayItems" "Display Items" initSettings.DisplayItems true
-                selectView "recurringPayments" "Recurring Payments" checkboxStateOptions
-                    (checkboxStateToString initSettings.RecurringPayments) false
-                selectView "smsNewsletterSubscription" "SMS Newsletter Subscription" checkboxStateOptions
-                    (checkboxStateToString initSettings.SmsNewsletterSubscription) false
-                selectView "emailNewsletterSubscription" "Email Newsletter Subscription" checkboxStateOptions
-                    (checkboxStateToString initSettings.EmailNewsletterSubscription) false
-                selectView "emailInvoice" "Email Invoice" checkboxStateOptions
-                    (checkboxStateToString initSettings.EmailInvoice) false
-                div [] [ h3 [] [ str "Extra Checkout Flags" ] ]
-                checkboxView "disableFocus" "Disable Focus" checkoutFlags.DisableFocus true
-                checkboxView "beforeSubmitCallbackEnabled" "Before Submit Callback Enabled"
-                    checkoutFlags.BeforeSubmitCallbackEnabled false
-                checkboxView "deliveryAddressChangedCallbackEnabled" "Delivery Address Changed Callback Enabled"
-                    checkoutFlags.DeliveryAddressChangedCallbackEnabled false
-                checkboxView "customStyles" "Use Custom Styles" checkoutFlags.CustomStyles true
-                div
-                    [ _style
-                        "display: flex; flex-direction: row; align-items: center; justify-content: space-between; padding: 20px 50px;" ]
-                    [ a
-                        [ _class "btn amado-btn active"
-                          _href "/" ] [ str "Back to Shop" ]
-                      input
-                          [ _class "btn amado-btn"
-                            _type "submit"
-                            _value "Save Settings" ] ] ] ]
+    div []
+        [ div [ _class "search-wrapper section-padding-100" ]
+              [ div [ _class "search-close" ]
+                    [ i
+                        [ _class "fa fa-close"
+                          _ariaHidden "true" ] [] ]
+                div [ _class "container" ]
+                    [ div [ _class "row" ]
+                          [ div [ _class "col-12" ]
+                                [ div [ _class "search-content" ]
+                                      [ form [ _action "#"; _method "get" ]
+                                            [ input
+                                                [ _type "search"
+                                                  _name "search"
+                                                  _id "search"
+                                                  _placeholder "Type your keyword..." ]
+                                              button [ _type "submit" ]
+                                                  [ img
+                                                      [ _src "/img/core-img/search.png"
+                                                        _alt "" ] ] ] ] ] ] ] ]
+          div [ _class "main-content-wrapper d-flex clearfix" ]
+              [ div [ _class "mobile-nav" ]
+                    [ div [ _class "amado-navbar-brand" ]
+                          [ a [ _href "/" ]
+                                [ img
+                                    [ _src "/img/core-img/logo.png"
+                                      _alt "" ] ] ]
+                      div [ _class "amado-navbar-toggler" ] [ span [] []; span [] []; span [] [] ] ]
+                headerView cartState
+                div [ _class "single-product-area section-padding-100 clearfix" ]
+                    [ div [ _class "container-fluid" ]
+                          [ div [ columnStyles ]
+                                [ form
+                                    [ _id "settings"
+                                      _action "/settings/save"
+                                      _method "POST" ]
+                                      [ div [] [ h3 [] [ str "Market" ] ]
+                                        selectView "market" "Market" [ "Sweden"; "Finland" ]
+                                            (marketToString settings.Market) true
+                                        div [] [ h3 [] [ str "Extra Identifiers" ] ]
+                                        inputView "orderReference" "Order Reference" settings.OrderReference true
+                                        div [] [ h3 [] [ str "Extra Init Options" ] ]
+                                        selectView "language" "Language"
+                                            [ "English"
+                                              "Swedish"
+                                              "Finnish"
+                                              "Norwegian"
+                                              "Estonian"
+                                              "Danish" ] (languageToString initSettings.Language) true
+                                        selectView "mode" "Mode" [ "b2c"; "b2b" ] "b2c" true
+                                        selectView "differentDeliveryAddress" "Different Delivery Address"
+                                            checkboxStateOptions
+                                            (checkboxStateToString initSettings.DifferentDeliveryAddress) true
+                                        checkboxView "displayItems" "Display Items" initSettings.DisplayItems true
+                                        selectView "recurringPayments" "Recurring Payments" checkboxStateOptions
+                                            (checkboxStateToString initSettings.RecurringPayments) true
+                                        selectView "smsNewsletterSubscription" "SMS Newsletter Subscription"
+                                            checkboxStateOptions
+                                            (checkboxStateToString initSettings.SmsNewsletterSubscription) true
+                                        selectView "emailNewsletterSubscription" "Email Newsletter Subscription"
+                                            checkboxStateOptions
+                                            (checkboxStateToString initSettings.EmailNewsletterSubscription) true
+                                        div [] [ h3 [] [ str "Extra Checkout Flags" ] ]
+                                        checkboxView "disableFocus" "Disable Focus" checkoutFlags.DisableFocus true
+                                        checkboxView "beforeSubmitCallbackEnabled" "Before Submit Callback Enabled"
+                                            checkoutFlags.BeforeSubmitCallbackEnabled true
+                                        checkboxView "deliveryAddressChangedCallbackEnabled"
+                                            "Delivery Address Changed Callback Enabled"
+                                            checkoutFlags.DeliveryAddressChangedCallbackEnabled true
+                                        checkboxView "customStyles" "Use Custom Styles" checkoutFlags.CustomStyles true
+                                        div
+                                            [ _style
+                                                "display: flex; flex-direction: row; align-items: center; justify-content: space-between; padding: 20px 50px;" ]
+                                            [ a
+                                                [ _class "btn amado-btn active"
+                                                  _href "/" ] [ str "Back to Shop" ]
+                                              input
+                                                  [ _class "btn amado-btn"
+                                                    _type "submit"
+                                                    _value "Save Settings" ] ] ] ] ] ] ]
+          subscribeSectionView
+          footerView ]
 
-let settingsView (settings: Settings) = [ template settings ] |> layout
+let settingsView (settings: Settings) (cartState: CartState) =
+    [ template settings cartState ] |> layout

--- a/src/Gir/WebRoot/js/checkout-integration.js
+++ b/src/Gir/WebRoot/js/checkout-integration.js
@@ -321,7 +321,9 @@ const initCheckout = (
   checkoutFrontendBundle,
   purchaseJwt,
   disableFocus,
-  useCustomStyles
+  useCustomStyles,
+  isBeforeSubmitCallbackEnabled,
+  isDeliveryAddressChangedCallbackEnabled
 ) => {
   (function (e, t, n, a, s, c, o, i, r) {
     e[a] =
@@ -395,6 +397,34 @@ const initCheckout = (
   const redirectUrlCallback = () =>
     window.location.origin + "/cart/#checkout-form";
 
+  var beforeSubmitCallback = function (
+    { zip, country, selectedPaymentMethodId },
+    checkoutInstance
+  ) {
+    var confirmAlert = confirm(
+      `Before Submit Callback Triggered:\nZip: "${zip}"\nCountry: "${country}"\nSelectedPaymentMethod: "${selectedPaymentMethodId}"\nPress 'OK' to continue or 'Cancel' to abort!`
+    );
+    if (confirmAlert == true) {
+      checkoutInstance.beforeSubmitContinue();
+    } else {
+      checkoutInstance.beforeSubmitAbort();
+    }
+  };
+
+  var deliveryAddressChangedCallback = function (
+    { zip, country },
+    checkoutInstance
+  ) {
+    var confirmAlert = confirm(
+      `Delivery Address Changed Callback Triggered:\nZip: "${zip}"\nCountry: "${country}"\nPress 'OK' to continue or 'Cancel' to abort!`
+    );
+    if (confirmAlert == true) {
+      checkoutInstance.deliveryAddressChangedContinue();
+    } else {
+      checkoutInstance.refreshForm();
+    }
+  };
+
   window.avardaCheckoutInit({
     purchaseJwt: purchaseJwt,
     rootElementId: "checkout-form",
@@ -404,5 +434,11 @@ const initCheckout = (
     handleByMerchantCallback: handleByMerchantCallback,
     completedPurchaseCallback: completedCallback,
     sessionTimedOutCallback: sessionTimedOutCallback,
+    beforeSubmitCallback: isBeforeSubmitCallbackEnabled
+      ? beforeSubmitCallback
+      : false,
+    deliveryAddressChangedCallback: isDeliveryAddressChangedCallbackEnabled
+      ? deliveryAddressChangedCallback
+      : false,
   });
 };


### PR DESCRIPTION
- use layout as on other pages
- enable all settings 
- send settings to Checkout Init or as Checkout flags
- trigger `confirm()` for optional callbacks
- add possibility to change order reference string