### PR TITLE
T25420: extend demoshop for apr widget

### DIFF
--- a/src/Gir/Decoders.fs
+++ b/src/Gir/Decoders.fs
@@ -112,12 +112,19 @@ let extraInitSettingsDecoder =
 
 let paymentWidgetSettingsDecoder =
     Decode.object (fun (get: Decode.IGetters) ->
-        { Enabled = get.Required.Field "enabled" Decode.bool
-          CustomStyles = get.Required.Field "customStyles" Decode.bool })
+        { Enabled = get.Required.Field "enabled" Decode.bool })
 
 let additionalFeaturesDecoder =
     Decode.object (fun (get: Decode.IGetters) ->
         { PartnerShippingEnabled = get.Required.Field "partnerShippingEnabled" Decode.bool })
+
+let aprWidgetSettingsDecoder =
+    Decode.object (fun (get: Decode.IGetters) ->
+        { AccountClass = get.Optional.Field "accountClass" Decode.string })
+
+let sharedWidgetSettingsDecoder =
+    Decode.object (fun (get: Decode.IGetters) -> 
+        { CustomStyles = get.Required.Field "customStyles" Decode.bool })
 
 let decodeSettings =
     Decode.object (fun (get: Decode.IGetters) ->
@@ -128,8 +135,11 @@ let decodeSettings =
             (get.Optional.Field "orderReference" Decode.string)
             |> Option.defaultValue defaultSettings.OrderReference
           PaymentWidgetSettings = get.Required.Field "paymentWidgetSettings" paymentWidgetSettingsDecoder
-          AdditionalFeatures = get.Required.Field "additionalFeatures" additionalFeaturesDecoder })
-
+          AdditionalFeatures = get.Required.Field "additionalFeatures" additionalFeaturesDecoder
+          AprWidgetSettings = get.Required.Field "aprWidgetSettings" aprWidgetSettingsDecoder
+          SharedWidgetSettings = get.Required.Field "sharedWidgetCustomStyles" sharedWidgetSettingsDecoder
+        })
+          
 let settingsDecoder (settingsString: string) =
     match Decode.fromString decodeSettings settingsString with
     | Ok settings -> settings

--- a/src/Gir/Decoders.fs
+++ b/src/Gir/Decoders.fs
@@ -111,8 +111,7 @@ let extraInitSettingsDecoder =
           SkipEmailZipEntry = get.Required.Field "skipEmailZipEntry" Decode.bool })
 
 let paymentWidgetSettingsDecoder =
-    Decode.object (fun (get: Decode.IGetters) ->
-        { Enabled = get.Required.Field "enabled" Decode.bool })
+    Decode.object (fun (get: Decode.IGetters) -> { Enabled = get.Required.Field "enabled" Decode.bool })
 
 let additionalFeaturesDecoder =
     Decode.object (fun (get: Decode.IGetters) ->
@@ -120,11 +119,11 @@ let additionalFeaturesDecoder =
 
 let aprWidgetSettingsDecoder =
     Decode.object (fun (get: Decode.IGetters) ->
-        { AccountClass = get.Optional.Field "accountClass" Decode.string })
+        { AccountClass = get.Optional.Field "accountClass" Decode.string
+          Enabled = get.Required.Field "enabled" Decode.bool })
 
 let sharedWidgetSettingsDecoder =
-    Decode.object (fun (get: Decode.IGetters) -> 
-        { CustomStyles = get.Required.Field "customStyles" Decode.bool })
+    Decode.object (fun (get: Decode.IGetters) -> { CustomStyles = get.Required.Field "customStyles" Decode.bool })
 
 let decodeSettings =
     Decode.object (fun (get: Decode.IGetters) ->
@@ -137,9 +136,8 @@ let decodeSettings =
           PaymentWidgetSettings = get.Required.Field "paymentWidgetSettings" paymentWidgetSettingsDecoder
           AdditionalFeatures = get.Required.Field "additionalFeatures" additionalFeaturesDecoder
           AprWidgetSettings = get.Required.Field "aprWidgetSettings" aprWidgetSettingsDecoder
-          SharedWidgetSettings = get.Required.Field "sharedWidgetCustomStyles" sharedWidgetSettingsDecoder
-        })
-          
+          SharedWidgetSettings = get.Required.Field "sharedWidgetCustomStyles" sharedWidgetSettingsDecoder })
+
 let settingsDecoder (settingsString: string) =
     match Decode.fromString decodeSettings settingsString with
     | Ok settings -> settings

--- a/src/Gir/Domain.fs
+++ b/src/Gir/Domain.fs
@@ -131,7 +131,9 @@ type PaymentWidgetSettings = { Enabled: bool }
 
 type AdditionalFeatures = { PartnerShippingEnabled: bool }
 
-type AprWidgetSettings = { AccountClass: string option }
+type AprWidgetSettings =
+    { AccountClass: string option
+      Enabled: bool }
 
 type SharedWidgetSettings = { CustomStyles: bool }
 
@@ -142,9 +144,8 @@ type Settings =
       OrderReference: string
       PaymentWidgetSettings: PaymentWidgetSettings
       AdditionalFeatures: AdditionalFeatures
-      AprWidgetSettings: AprWidgetSettings 
-      SharedWidgetSettings: SharedWidgetSettings
-    }
+      AprWidgetSettings: AprWidgetSettings
+      SharedWidgetSettings: SharedWidgetSettings }
 
 let languageToString =
     function
@@ -341,17 +342,15 @@ let defaultExtraInitSettings: ExtraInitSettings =
       UseCustomEmailNewsletterSubscriptionText = false
       SkipEmailZipEntry = false }
 
-let defaultPaymentWidgetSettings: PaymentWidgetSettings =
-    { Enabled = false }
+let defaultPaymentWidgetSettings: PaymentWidgetSettings = { Enabled = false }
 
 let defaultAprWidgetSettings: AprWidgetSettings =
-    { AccountClass = None }
+    { AccountClass = None; Enabled = false }
 
 let defaultAdditionalFeatures: AdditionalFeatures =
     { PartnerShippingEnabled = false }
 
-let defaultSharedWidgetSettings: SharedWidgetSettings =
-    { CustomStyles = false }
+let defaultSharedWidgetSettings: SharedWidgetSettings = { CustomStyles = false }
 
 let defaultSettings: Settings =
     { ExtraCheckoutFlags = defaultExtraCheckoutFlags
@@ -361,8 +360,7 @@ let defaultSettings: Settings =
       PaymentWidgetSettings = defaultPaymentWidgetSettings
       AdditionalFeatures = defaultAdditionalFeatures
       AprWidgetSettings = defaultAprWidgetSettings
-      SharedWidgetSettings = defaultSharedWidgetSettings 
-    }
+      SharedWidgetSettings = defaultSharedWidgetSettings }
 
 type ExtraIdentifiers = { OrderReference: string }
 

--- a/src/Gir/Domain.fs
+++ b/src/Gir/Domain.fs
@@ -127,10 +127,13 @@ type Market =
     | Germany
     | Austria
 
-type PaymentWidgetSettings = { Enabled: bool; CustomStyles: bool }
-
+type PaymentWidgetSettings = { Enabled: bool }
 
 type AdditionalFeatures = { PartnerShippingEnabled: bool }
+
+type AprWidgetSettings = { AccountClass: string option }
+
+type SharedWidgetSettings = { CustomStyles: bool }
 
 type Settings =
     { ExtraCheckoutFlags: ExtraCheckoutFlags
@@ -138,7 +141,10 @@ type Settings =
       Market: Market
       OrderReference: string
       PaymentWidgetSettings: PaymentWidgetSettings
-      AdditionalFeatures: AdditionalFeatures }
+      AdditionalFeatures: AdditionalFeatures
+      AprWidgetSettings: AprWidgetSettings 
+      SharedWidgetSettings: SharedWidgetSettings
+    }
 
 let languageToString =
     function
@@ -336,11 +342,16 @@ let defaultExtraInitSettings: ExtraInitSettings =
       SkipEmailZipEntry = false }
 
 let defaultPaymentWidgetSettings: PaymentWidgetSettings =
-    { Enabled = false
-      CustomStyles = false }
+    { Enabled = false }
+
+let defaultAprWidgetSettings: AprWidgetSettings =
+    { AccountClass = None }
 
 let defaultAdditionalFeatures: AdditionalFeatures =
     { PartnerShippingEnabled = false }
+
+let defaultSharedWidgetSettings: SharedWidgetSettings =
+    { CustomStyles = false }
 
 let defaultSettings: Settings =
     { ExtraCheckoutFlags = defaultExtraCheckoutFlags
@@ -348,7 +359,10 @@ let defaultSettings: Settings =
       Market = Sweden
       OrderReference = "TEST-AVARDA-DEMO-SHOP"
       PaymentWidgetSettings = defaultPaymentWidgetSettings
-      AdditionalFeatures = defaultAdditionalFeatures }
+      AdditionalFeatures = defaultAdditionalFeatures
+      AprWidgetSettings = defaultAprWidgetSettings
+      SharedWidgetSettings = defaultSharedWidgetSettings 
+    }
 
 type ExtraIdentifiers = { OrderReference: string }
 

--- a/src/Gir/Encoders.fs
+++ b/src/Gir/Encoders.fs
@@ -159,11 +159,18 @@ let extraCheckoutFlagsEncoder (checkoutFlags: ExtraCheckoutFlags) =
 
 let paymentWidgetSettingsEncoder (paymentWidgetSettings: PaymentWidgetSettings) =
     Encode.object
-        [ "enabled", Encode.bool paymentWidgetSettings.Enabled
-          "customStyles", Encode.bool paymentWidgetSettings.CustomStyles ]
+        [ "enabled", Encode.bool paymentWidgetSettings.Enabled ]
+
+let aprWidgetSettingEncoder (aprWidgetSettings: AprWidgetSettings) =
+    Encode.object 
+        [ "accountClass", Encode.option Encode.string aprWidgetSettings.AccountClass ]
 
 let additionalFeaturesEncoder (additionalFeatures: AdditionalFeatures) =
     Encode.object [ "partnerShippingEnabled", Encode.bool additionalFeatures.PartnerShippingEnabled ]
+
+let sharedWidgetSettingsEncoder (sharedWidgetSettings: SharedWidgetSettings) =
+    Encode.object
+        [ "customStyles", Encode.bool sharedWidgetSettings.CustomStyles ]
 
 let settingsEncoder (settings: Settings) =
     Encode.object
@@ -172,7 +179,9 @@ let settingsEncoder (settings: Settings) =
           "market", settings.Market |> marketToString |> Encode.string
           "orderReference", Encode.string settings.OrderReference
           "paymentWidgetSettings", paymentWidgetSettingsEncoder settings.PaymentWidgetSettings
-          "additionalFeatures", additionalFeaturesEncoder settings.AdditionalFeatures ]
+          "additionalFeatures", additionalFeaturesEncoder settings.AdditionalFeatures
+          "aprWidgetSettings", aprWidgetSettingEncoder settings.AprWidgetSettings 
+          "sharedWidgetCustomStyles", sharedWidgetSettingsEncoder settings.SharedWidgetSettings ]
     |> Encode.toString 0
 
 

--- a/src/Gir/Encoders.fs
+++ b/src/Gir/Encoders.fs
@@ -158,19 +158,18 @@ let extraCheckoutFlagsEncoder (checkoutFlags: ExtraCheckoutFlags) =
           "extras", extrasEncoder checkoutFlags.Extras ]
 
 let paymentWidgetSettingsEncoder (paymentWidgetSettings: PaymentWidgetSettings) =
-    Encode.object
-        [ "enabled", Encode.bool paymentWidgetSettings.Enabled ]
+    Encode.object [ "enabled", Encode.bool paymentWidgetSettings.Enabled ]
 
 let aprWidgetSettingEncoder (aprWidgetSettings: AprWidgetSettings) =
-    Encode.object 
-        [ "accountClass", Encode.option Encode.string aprWidgetSettings.AccountClass ]
+    Encode.object
+        [ "accountClass", Encode.option Encode.string aprWidgetSettings.AccountClass
+          "enabled", Encode.bool aprWidgetSettings.Enabled ]
 
 let additionalFeaturesEncoder (additionalFeatures: AdditionalFeatures) =
     Encode.object [ "partnerShippingEnabled", Encode.bool additionalFeatures.PartnerShippingEnabled ]
 
 let sharedWidgetSettingsEncoder (sharedWidgetSettings: SharedWidgetSettings) =
-    Encode.object
-        [ "customStyles", Encode.bool sharedWidgetSettings.CustomStyles ]
+    Encode.object [ "customStyles", Encode.bool sharedWidgetSettings.CustomStyles ]
 
 let settingsEncoder (settings: Settings) =
     Encode.object
@@ -180,7 +179,7 @@ let settingsEncoder (settings: Settings) =
           "orderReference", Encode.string settings.OrderReference
           "paymentWidgetSettings", paymentWidgetSettingsEncoder settings.PaymentWidgetSettings
           "additionalFeatures", additionalFeaturesEncoder settings.AdditionalFeatures
-          "aprWidgetSettings", aprWidgetSettingEncoder settings.AprWidgetSettings 
+          "aprWidgetSettings", aprWidgetSettingEncoder settings.AprWidgetSettings
           "sharedWidgetCustomStyles", sharedWidgetSettingsEncoder settings.SharedWidgetSettings ]
     |> Encode.toString 0
 

--- a/src/Gir/Products/HttpHandlers.fs
+++ b/src/Gir/Products/HttpHandlers.fs
@@ -35,7 +35,7 @@ let detailHandler
         | Some product ->
             if
                 isPaymentWidgetEnabledGlobally paymentWidgetBundleUrl
-                && (settings.PaymentWidgetSettings.Enabled || Option.isSome settings.AprWidgetSettings.AccountClass)
+                && (settings.PaymentWidgetSettings.Enabled || settings.AprWidgetSettings.Enabled)
             then
                 match Session.tryGetPaymentWidgetState ctx with
                 | Some paymentWidgetState ->

--- a/src/Gir/Products/HttpHandlers.fs
+++ b/src/Gir/Products/HttpHandlers.fs
@@ -35,7 +35,7 @@ let detailHandler
         | Some product ->
             if
                 isPaymentWidgetEnabledGlobally paymentWidgetBundleUrl
-                && settings.PaymentWidgetSettings.Enabled
+                && (settings.PaymentWidgetSettings.Enabled || Option.isSome settings.AprWidgetSettings.AccountClass)
             then
                 match Session.tryGetPaymentWidgetState ctx with
                 | Some paymentWidgetState ->

--- a/src/Gir/Products/Views.fs
+++ b/src/Gir/Products/Views.fs
@@ -5,7 +5,6 @@ open Giraffe.ViewEngine
 open Gir.Layout
 open Gir.Domain
 open Gir.Utils
-open System.Xml
 
 
 

--- a/src/Gir/Products/Views.fs
+++ b/src/Gir/Products/Views.fs
@@ -460,7 +460,7 @@ let listView (settings: Settings) (cartState: CartState) (products: Product list
 
 let languageSelectView (widgetName: string) =
     let widgetHeader =
-      match widgetName with
+        match widgetName with
         | "avarda-payment-widget" -> "Payment Widget"
         | "avarda-apr-widget" -> "APR Widget"
         | _ -> "Widget"
@@ -527,30 +527,34 @@ let detailTemplate
     let selectedLanguageIsoCode =
         settings.ExtraInitSettings.Language |> languageToIsoCode
 
-    
-    let aprWidgetView (accountClassString: string) =
-      aprWidget
-        [ _languageAttribute selectedLanguageIsoCode
-          _paymentMethod "Invoice" 
-          _accountClass accountClassString ] 
-        [ str "" ]    
-          
 
-    let aprWidgetsView (test: string option) =
-      match test with
-      | Some str ->
-          let accountClassListFromString = 
-              str.Split([|';'|], System.StringSplitOptions.RemoveEmptyEntries)
+    let aprWidgetView (accountClassString: string) =
+        aprWidget
+            [ _languageAttribute selectedLanguageIsoCode
+              _paymentMethod "Invoice"
+              _accountClass accountClassString ]
+            [ str "" ]
+
+    let aprWidgetsView (accountClassSettings: string option) =
+        match accountClassSettings with
+        | Some str ->
+            let accountClassListFromString =
+                str.Split([| ';' |], System.StringSplitOptions.RemoveEmptyEntries)
                 |> Array.map (fun s -> s.Trim())
                 |> Array.toList
 
-          let aprWidgetElementView =
-            [languageSelectView "avarda-apr-widget"]
-            |> List.append (accountClassListFromString |> List.map aprWidgetView)
+            let aprWidgetElementView =
+                [ languageSelectView "avarda-apr-widget" ]
+                |> List.append (accountClassListFromString |> List.map aprWidgetView)
 
-          div [] aprWidgetElementView
+            div [] aprWidgetElementView
 
-      | None -> div [] []
+        | None ->
+            div
+                []
+                [ aprWidget [ _languageAttribute selectedLanguageIsoCode; _paymentMethod "Invoice" ] [ str "" ]
+                  (languageSelectView "avarda-apr-widget") ]
+
 
     div
         []
@@ -723,12 +727,13 @@ let detailTemplate
                                                             [ _priceAttribute <| sprintf "%M" product.Price
                                                               _languageAttribute selectedLanguageIsoCode ]
                                                             [ str "" ]
-                                                        languageSelectView "avarda-payment-widget"
-                                                      ]  
+                                                        languageSelectView "avarda-payment-widget" ]
                                               else
-                                                 str "" 
-                                              aprWidgetsView settings.AprWidgetSettings.AccountClass
-                                              ] ] ] ] ] ]
+                                                  str ""
+                                              if settings.AprWidgetSettings.Enabled then
+                                                  aprWidgetsView settings.AprWidgetSettings.AccountClass
+                                              else
+                                                  str "" ] ] ] ] ] ]
           subscribeSectionView
           footerView
           paymentWidgetScriptView paymentWidgetBundleUrl settings.SharedWidgetSettings paymentWidgetState apiPublicUrl ]

--- a/src/Gir/Products/Views.fs
+++ b/src/Gir/Products/Views.fs
@@ -540,7 +540,7 @@ let detailTemplate
         | Some str ->
             let accountClassListFromString =
                 str.Split([| ';' |], System.StringSplitOptions.RemoveEmptyEntries)
-                |> Array.map (fun s -> s.Trim())
+                |> Array.map (fun accountClassName -> accountClassName.Trim())
                 |> Array.toList
 
             let aprWidgetElementView =

--- a/src/Gir/Products/Views.fs
+++ b/src/Gir/Products/Views.fs
@@ -1,17 +1,25 @@
 module Gir.Products.Views
 
+
 open Giraffe.ViewEngine
 open Gir.Layout
 open Gir.Domain
 open Gir.Utils
+open System.Xml
 
 
 
 let avardaPaymentWidget = tag "avarda-payment-widget"
 
+let aprWidget = tag "avarda-apr-widget"
+
 let _priceAttribute = attr "price"
 
 let _languageAttribute = attr "lang"
+
+let _accountClass = attr "account-class"
+
+let _paymentMethod = attr "payment-method"
 
 let _widgetJwtAttribute = attr "data-widget-jwt"
 
@@ -451,7 +459,6 @@ let listTemplate (settings: Settings) (cartState: CartState) (productList: Produ
 let listView (settings: Settings) (cartState: CartState) (products: Product list) =
     [ listTemplate settings cartState products ] |> layout
 
-
 let languageSelectView =
     details
         []
@@ -461,7 +468,7 @@ let languageSelectView =
               [ button
                     [ _class "select-flag"
                       _id "flag-en"
-                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'en');" ]
+                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'en'); document.querySelector('avarda-apr-widget').setAttribute('lang', 'en');" ]
                     [ img
                           [ _class "flag"
                             _src "/img/flags/gb.svg"
@@ -470,7 +477,7 @@ let languageSelectView =
                 button
                     [ _class "select-flag"
                       _id "flag-se"
-                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'sv');" ]
+                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'sv'); document.querySelector('avarda-apr-widget').setAttribute('lang', 'sv');" ]
                     [ img
                           [ _class "flag"
                             _src "/img/flags/se.svg"
@@ -479,7 +486,7 @@ let languageSelectView =
                 button
                     [ _class "select-flag"
                       _id "flag-no"
-                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'nb');" ]
+                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'nb'); document.querySelector('avarda-apr-widget').setAttribute('lang', 'nb');" ]
                     [ img
                           [ _class "flag"
                             _src "/img/flags/no.svg"
@@ -488,7 +495,7 @@ let languageSelectView =
                 button
                     [ _class "select-flag"
                       _id "flag-dk"
-                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'da');" ]
+                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'da'); document.querySelector('avarda-apr-widget').setAttribute('lang', 'da');" ]
                     [ img
                           [ _class "flag"
                             _src "/img/flags/dk.svg"
@@ -497,13 +504,12 @@ let languageSelectView =
                 button
                     [ _class "select-flag"
                       _id "flag-fi"
-                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'fi');" ]
+                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'fi'); document.querySelector('avarda-apr-widget').setAttribute('lang', 'fi');" ]
                     [ img
                           [ _class "flag"
                             _src "/img/flags/fi.svg"
                             _alt "Finnish language"
                             _ariaHidden "true" ] ] ] ]
-
 
 let detailTemplate
     (settings: Settings)
@@ -687,7 +693,13 @@ let detailTemplate
                                                             [ _priceAttribute <| sprintf "%M" product.Price
                                                               _languageAttribute selectedLanguageIsoCode ]
                                                             [ str "" ]
-                                                        languageSelectView ]
+                                                        aprWidget
+                                                            [ _languageAttribute selectedLanguageIsoCode
+                                                              _paymentMethod "Invoice" 
+                                                              _accountClass "214124124" ]
+                                                            [ str "" ]
+                                                        languageSelectView
+                                                      ]  
                                               else
                                                   str "" ] ] ] ] ] ]
           subscribeSectionView

--- a/src/Gir/Products/Views.fs
+++ b/src/Gir/Products/Views.fs
@@ -379,7 +379,7 @@ let rawCustomStyles (apiPublicUrl: string) =
 
 let paymentWidgetScriptView
     (paymentWidgetBundleUrl: string)
-    (paymentWidgetSettings: PaymentWidgetSettings)
+    (sharedWidgetCustomStyles: SharedWidgetSettings)
     (paymentWidgetState: PaymentWidgetState option)
     (apiPublicUrl: string)
     =
@@ -394,7 +394,7 @@ let paymentWidgetScriptView
             + "?ts="
             + System.DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString()
 
-        if paymentWidgetSettings.CustomStyles then
+        if sharedWidgetCustomStyles.CustomStyles then
             script
                 [ _async
                   _crossorigin "annonymous"
@@ -458,16 +458,22 @@ let listTemplate (settings: Settings) (cartState: CartState) (productList: Produ
 let listView (settings: Settings) (cartState: CartState) (products: Product list) =
     [ listTemplate settings cartState products ] |> layout
 
-let languageSelectView =
+let languageSelectView (widgetName: string) =
+    let widgetHeader =
+      match widgetName with
+        | "avarda-payment-widget" -> "Payment Widget"
+        | "avarda-apr-widget" -> "APR Widget"
+        | _ -> "Widget"
+
     details
         []
-        [ summary [ _class "select-language-summary" ] [ str "Select language of Payment Widget" ]
+        [ summary [ _class "select-language-summary" ] [ str $"Select language of {widgetHeader}" ]
           div
               [ _class "select-language-container" ]
               [ button
                     [ _class "select-flag"
                       _id "flag-en"
-                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'en'); document.querySelector('avarda-apr-widget').setAttribute('lang', 'en');" ]
+                      _onclick $"document.querySelector('{widgetName}').setAttribute('lang', 'en')" ]
                     [ img
                           [ _class "flag"
                             _src "/img/flags/gb.svg"
@@ -476,7 +482,7 @@ let languageSelectView =
                 button
                     [ _class "select-flag"
                       _id "flag-se"
-                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'sv'); document.querySelector('avarda-apr-widget').setAttribute('lang', 'sv');" ]
+                      _onclick $"document.querySelector('{widgetName}').setAttribute('lang', 'sv')" ]
                     [ img
                           [ _class "flag"
                             _src "/img/flags/se.svg"
@@ -485,7 +491,7 @@ let languageSelectView =
                 button
                     [ _class "select-flag"
                       _id "flag-no"
-                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'nb'); document.querySelector('avarda-apr-widget').setAttribute('lang', 'nb');" ]
+                      _onclick $"document.querySelector('{widgetName}').setAttribute('lang', 'nb')" ]
                     [ img
                           [ _class "flag"
                             _src "/img/flags/no.svg"
@@ -494,7 +500,7 @@ let languageSelectView =
                 button
                     [ _class "select-flag"
                       _id "flag-dk"
-                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'da'); document.querySelector('avarda-apr-widget').setAttribute('lang', 'da');" ]
+                      _onclick $"document.querySelector('{widgetName}').setAttribute('lang', 'da')" ]
                     [ img
                           [ _class "flag"
                             _src "/img/flags/dk.svg"
@@ -503,7 +509,7 @@ let languageSelectView =
                 button
                     [ _class "select-flag"
                       _id "flag-fi"
-                      _onclick "document.querySelector('avarda-payment-widget').setAttribute('lang', 'fi'); document.querySelector('avarda-apr-widget').setAttribute('lang', 'fi');" ]
+                      _onclick $"document.querySelector('{widgetName}').setAttribute('lang', 'fi');" ]
                     [ img
                           [ _class "flag"
                             _src "/img/flags/fi.svg"
@@ -520,6 +526,31 @@ let detailTemplate
     =
     let selectedLanguageIsoCode =
         settings.ExtraInitSettings.Language |> languageToIsoCode
+
+    
+    let aprWidgetView (accountClassString: string) =
+      aprWidget
+        [ _languageAttribute selectedLanguageIsoCode
+          _paymentMethod "Invoice" 
+          _accountClass accountClassString ] 
+        [ str "" ]    
+          
+
+    let aprWidgetsView (test: string option) =
+      match test with
+      | Some str ->
+          let accountClassListFromString = 
+              str.Split([|';'|], System.StringSplitOptions.RemoveEmptyEntries)
+                |> Array.map (fun s -> s.Trim())
+                |> Array.toList
+
+          let aprWidgetElementView =
+            [languageSelectView "avarda-apr-widget"]
+            |> List.append (accountClassListFromString |> List.map aprWidgetView)
+
+          div [] aprWidgetElementView
+
+      | None -> div [] []
 
     div
         []
@@ -692,18 +723,15 @@ let detailTemplate
                                                             [ _priceAttribute <| sprintf "%M" product.Price
                                                               _languageAttribute selectedLanguageIsoCode ]
                                                             [ str "" ]
-                                                        aprWidget
-                                                            [ _languageAttribute selectedLanguageIsoCode
-                                                              _paymentMethod "Invoice" 
-                                                              _accountClass "214124124" ]
-                                                            [ str "" ]
-                                                        languageSelectView
+                                                        languageSelectView "avarda-payment-widget"
                                                       ]  
                                               else
-                                                  str "" ] ] ] ] ] ]
+                                                 str "" 
+                                              aprWidgetsView settings.AprWidgetSettings.AccountClass
+                                              ] ] ] ] ] ]
           subscribeSectionView
           footerView
-          paymentWidgetScriptView paymentWidgetBundleUrl settings.PaymentWidgetSettings paymentWidgetState apiPublicUrl ]
+          paymentWidgetScriptView paymentWidgetBundleUrl settings.SharedWidgetSettings paymentWidgetState apiPublicUrl ]
 
 let productDetailView
     (settings: Settings)

--- a/src/Gir/Settings/HttpHandlers.fs
+++ b/src/Gir/Settings/HttpHandlers.fs
@@ -77,9 +77,13 @@ let saveSettingsHandler (next: HttpFunc) (ctx: HttpContext) =
               Market = getValue "market" |> stringToMarket
               OrderReference = getValue "orderReference"
               PaymentWidgetSettings =
-                { Enabled = checkboxValue "paymentWidgetEnabled"
-                  CustomStyles = checkboxValue "paymentWidgetCustomStyles" }
-              AdditionalFeatures = { PartnerShippingEnabled = checkboxValue "partnerShippingEnabled" } }
+                { Enabled = checkboxValue "paymentWidgetEnabled" }
+              AdditionalFeatures = { PartnerShippingEnabled = checkboxValue "partnerShippingEnabled" } 
+              AprWidgetSettings =
+                { AccountClass = getTextAreaValue "aprWidgetEnabled" }
+              SharedWidgetSettings =
+                { CustomStyles = checkboxValue "sharedWidgetCustomStyles" }
+            }
 
         Session.setSettings ctx formData
         Session.deleteCartState ctx

--- a/src/Gir/Settings/HttpHandlers.fs
+++ b/src/Gir/Settings/HttpHandlers.fs
@@ -76,14 +76,12 @@ let saveSettingsHandler (next: HttpFunc) (ctx: HttpContext) =
                   SkipEmailZipEntry = checkboxValue "skipEmailZipEntry" }
               Market = getValue "market" |> stringToMarket
               OrderReference = getValue "orderReference"
-              PaymentWidgetSettings =
-                { Enabled = checkboxValue "paymentWidgetEnabled" }
-              AdditionalFeatures = { PartnerShippingEnabled = checkboxValue "partnerShippingEnabled" } 
+              PaymentWidgetSettings = { Enabled = checkboxValue "paymentWidgetEnabled" }
+              AdditionalFeatures = { PartnerShippingEnabled = checkboxValue "partnerShippingEnabled" }
               AprWidgetSettings =
-                { AccountClass = getTextAreaValue "aprWidgetEnabled" }
-              SharedWidgetSettings =
-                { CustomStyles = checkboxValue "sharedWidgetCustomStyles" }
-            }
+                { AccountClass = getTextAreaValue "aprWidgetAccountClass"
+                  Enabled = checkboxValue "aprWidgetEnabled" }
+              SharedWidgetSettings = { CustomStyles = checkboxValue "sharedWidgetCustomStyles" } }
 
         Session.setSettings ctx formData
         Session.deleteCartState ctx

--- a/src/Gir/Settings/Views.fs
+++ b/src/Gir/Settings/Views.fs
@@ -176,7 +176,9 @@ let template
     let { ExtraInitSettings = initSettings
           ExtraCheckoutFlags = checkoutFlags
           PaymentWidgetSettings = paymentWidgetSettings
-          AdditionalFeatures = additionalFeatures } =
+          AdditionalFeatures = additionalFeatures
+          AprWidgetSettings = aprWidgetSettings
+          SharedWidgetSettings = sharedWidgetSettings } =
         settings
 
     let marketsOptions =
@@ -420,18 +422,26 @@ let template
                                                 "Make sure you enable either SMS or Email newsletter checkbox in order to display extra t&c")
                                             checkoutFlags.Extras.ExtraTermsAndConditions
                                             true
-                                        div [] [ h3 [ _class "settings-heading" ] [ str "Payment Widget" ] ]
+                                        div [] [ h3 [ _class "settings-heading" ] [ str "Payment and APR Widget" ] ]
                                         checkboxView
                                             "paymentWidgetEnabled"
                                             "Enable Payment Widget"
                                             paymentWidgetHelpText
                                             paymentWidgetSettings.Enabled
                                             (isPaymentWidgetEnabledGlobally paymentWidgetBundleUrl)
+                                        textareaView
+                                            "aprWidgetEnabled"
+                                            "Enable APR Widget"
+                                            (Some
+                                                "To enable the APR widget, please enter the account class in the text area field. If you need to enable multiple widgets, enter the numbers separated by semicolons, like this: 1;2;3."
+                                            )
+                                            aprWidgetSettings.AccountClass
+                                            (isPaymentWidgetEnabledGlobally paymentWidgetBundleUrl)
                                         checkboxView
-                                            "paymentWidgetCustomStyles"
-                                            "Use Custom Styles in Payment Widget"
+                                            "sharedWidgetCustomStyles"
+                                            "Use Custom Styles in Widgets"
                                             None
-                                            paymentWidgetSettings.CustomStyles
+                                            sharedWidgetSettings.CustomStyles
                                             (isPaymentWidgetEnabledGlobally paymentWidgetBundleUrl)
                                         div [] [ h3 [ _class "settings-heading" ] [ str "Additional Features" ] ]
                                         checkboxView

--- a/src/Gir/Settings/Views.fs
+++ b/src/Gir/Settings/Views.fs
@@ -429,12 +429,17 @@ let template
                                             paymentWidgetHelpText
                                             paymentWidgetSettings.Enabled
                                             (isPaymentWidgetEnabledGlobally paymentWidgetBundleUrl)
-                                        textareaView
+                                        checkboxView
                                             "aprWidgetEnabled"
                                             "Enable APR Widget"
+                                            paymentWidgetHelpText
+                                            aprWidgetSettings.Enabled
+                                            (isPaymentWidgetEnabledGlobally paymentWidgetBundleUrl)
+                                        textareaView
+                                            "aprWidgetAccountClass"
+                                            "Add APR Account class"
                                             (Some
-                                                "To enable the APR widget, please enter the account class in the text area field. If you need to enable multiple widgets, enter the numbers separated by semicolons, like this: 1;2;3."
-                                            )
+                                                "To enable the APR widget, please enter the account class in the text area field. If you need to enable multiple widgets, enter the numbers separated by semicolons, like this: 1;2;3.")
                                             aprWidgetSettings.AccountClass
                                             (isPaymentWidgetEnabledGlobally paymentWidgetBundleUrl)
                                         checkboxView

--- a/src/Gir/Settings/Views.fs
+++ b/src/Gir/Settings/Views.fs
@@ -439,7 +439,7 @@ let template
                                             "aprWidgetAccountClass"
                                             "Add APR Account class"
                                             (Some
-                                                "To enable the APR widget, please enter the account class in the text area field. If you need to enable multiple widgets, enter the numbers separated by semicolons, like this: 1;2;3.")
+                                                "Please enter the account class in the text area field. If you need to initializate multiple widgets, enter the numbers separated by semicolons, like this: 1;2;3.")
                                             aprWidgetSettings.AccountClass
                                             (isPaymentWidgetEnabledGlobally paymentWidgetBundleUrl)
                                         checkboxView


### PR DESCRIPTION
Added init of APR widget to demoshop. 
Extended settings page, merged custom styles option to be used for both widgets.
Widget is displayed on product page, same as payment widget.