### PR TITLE
T28089: Extend settings with shipping options, add qol changes

### DIFF
--- a/src/Gir/Cart/CheckoutIntegration.fs
+++ b/src/Gir/Cart/CheckoutIntegration.fs
@@ -29,7 +29,7 @@ let getRequestPartnerAccessToken (url: string) (clientId: string) (clientSecret:
     }
 
 let isValid (tokenString: string) =
-    let handler = JsonWebTokenHandler()
+    let handler: JsonWebTokenHandler = JsonWebTokenHandler()
     let jwt = handler.ReadJsonWebToken(tokenString)
 
     if jwt.ValidTo > System.DateTime.UtcNow then

--- a/src/Gir/Cart/HttpHandlers.fs
+++ b/src/Gir/Cart/HttpHandlers.fs
@@ -103,7 +103,12 @@ let cartHandler
         if List.isEmpty cartState.Items then
             return!
                 htmlView
-                    (cartView settings cartState checkoutFrontendBundleUrl "" partnerShippingBundleUrl
+                    (cartView
+                        settings
+                        cartState
+                        checkoutFrontendBundleUrl
+                        { PurchaseToken = ""; PurchaseId = "" }
+                        partnerShippingBundleUrl
                      <| getProducts ())
                     next
                     ctx
@@ -116,18 +121,31 @@ let cartHandler
 
                 return!
                     htmlView
-                        (cartView settings cartState checkoutFrontendBundleUrl purchaseToken partnerShippingBundleUrl
+                        (cartView
+                            settings
+                            cartState
+                            checkoutFrontendBundleUrl
+                            { PurchaseToken = purchaseToken
+                              PurchaseId = purchaseId }
+                            partnerShippingBundleUrl
                          <| getProducts ())
                         next
                         ctx
             | None ->
                 let! initPurchaseResponse = getPurchaseToken cartState partnerToken settings
                 let purchaseToken = initPurchaseResponse.Jwt
-                Session.setPurchaseId ctx initPurchaseResponse.PurchaseId
+                let purchaseId = initPurchaseResponse.PurchaseId
+                Session.setPurchaseId ctx purchaseId
 
                 return!
                     htmlView
-                        (cartView settings cartState checkoutFrontendBundleUrl purchaseToken partnerShippingBundleUrl
+                        (cartView
+                            settings
+                            cartState
+                            checkoutFrontendBundleUrl
+                            { PurchaseToken = purchaseToken
+                              PurchaseId = purchaseId }
+                            partnerShippingBundleUrl
                          <| getProducts ())
                         next
                         ctx

--- a/src/Gir/CompositionRoot.fs
+++ b/src/Gir/CompositionRoot.fs
@@ -19,30 +19,191 @@ type CompositionRoot =
       PartnerShippingBundle: string }
 
 let dummyProducts: Product list =
-    let createProduct id name price img bigImg =
+    let createProduct id name price img bigImg shippingParameters =
         { ProductId = id
           Name = name
           Price = price
           Img = img
-          BigImg = bigImg }
+          BigImg = bigImg
+          ShippingParameters = shippingParameters }
 
-    [ createProduct 1 "Modern Chair" 180M "/img/bg-img/1.jpg" "/img/product-img/pro-big-1.jpg"
-      createProduct 2 "Minimalistic Plant Pot" 10M "/img/bg-img/2.jpg" "/img/product-img/pro-big-2.jpg"
-      createProduct 3 "Night Stand" 2500M "/img/bg-img/4.jpg" "/img/product-img/pro-big-4.jpg"
-      createProduct 4 "Plant Pot" 3M "/img/bg-img/5.jpg" "/img/product-img/pro-big-5.jpg"
-      createProduct 5 "Large Table" 1100M "/img/bg-img/6.jpg" "/img/product-img/pro-big-6.jpg"
-      createProduct 6 "Metallic Chair" 317M "/img/bg-img/7.jpg" "/img/product-img/pro-big-7.jpg"
-      createProduct 7 "Rocking Chair" 100M "/img/bg-img/8.jpg" "/img/product-img/pro-big-8.jpg"
-      createProduct 8 "Modern Chair" 50M "/img/bg-img/1.jpg" "/img/product-img/pro-big-1.jpg"
-      createProduct 9 "Minimalistic Plant Pot - Discounted" 5M "/img/bg-img/2.jpg" "/img/product-img/pro-big-2.jpg"
-      createProduct 10 "Table Lamp" 30.50M "/img/bg-img/10.jpg" "/img/product-img/pro-big-10.jpg"
-      createProduct 11 "Expensive Dinning Set" 1800.99M "/img/bg-img/11.jpg" "/img/product-img/pro-big-11.jpg"
-      createProduct 12 "Plant Deco Set Wall" 2500M "/img/bg-img/12.jpg" "/img/product-img/pro-big-12.jpg"
-      createProduct 13 "Punk Chair" 10.99M "/img/bg-img/13.jpg" "/img/product-img/pro-big-13.jpg"
-      createProduct 14 "Huge Leather Sofa" 3999M "/img/bg-img/14.jpg" "/img/product-img/pro-big-14.jpg"
-      createProduct 15 "Day Stand" 199M "/img/bg-img/15.jpg" "/img/product-img/pro-big-15.jpg"
-      createProduct 16 "Cool Chair" 100M "/img/bg-img/16.jpg" "/img/product-img/pro-big-16.jpg"
-      createProduct 17 "Cozy Cabinets" 50M "/img/bg-img/17.jpg" "/img/product-img/pro-big-17.jpg" ]
+    [ createProduct
+          1
+          "Modern Chair"
+          180M
+          "/img/bg-img/1.jpg"
+          "/img/product-img/pro-big-1.jpg"
+          { Height = 9000
+            Length = 6000
+            Width = 3000
+            Weight = 1000
+            Attributes = [] }
+      createProduct
+          2
+          "Minimalistic Plant Pot"
+          10M
+          "/img/bg-img/2.jpg"
+          "/img/product-img/pro-big-2.jpg"
+          { Height = 2000
+            Length = 4000
+            Width = 4000
+            Weight = 300
+            Attributes = [] }
+      createProduct
+          3
+          "Night Stand"
+          2500M
+          "/img/bg-img/4.jpg"
+          "/img/product-img/pro-big-4.jpg"
+          { Height = 8000
+            Length = 5000
+            Width = 3000
+            Weight = 2000
+            Attributes = [] }
+      createProduct
+          4
+          "Plant Pot"
+          3M
+          "/img/bg-img/5.jpg"
+          "/img/product-img/pro-big-5.jpg"
+          { Height = 10000
+            Length = 8000
+            Width = 5000
+            Weight = 1500
+            Attributes = [] }
+      createProduct
+          5
+          "Large Table"
+          1100M
+          "/img/bg-img/6.jpg"
+          "/img/product-img/pro-big-6.jpg"
+          { Height = 8500
+            Length = 16000
+            Width = 8000
+            Weight = 20000
+            Attributes = [] }
+      createProduct
+          6
+          "Metallic Chair"
+          317M
+          "/img/bg-img/7.jpg"
+          "/img/product-img/pro-big-7.jpg"
+          { Height = 8500
+            Length = 5500
+            Width = 4000
+            Weight = 1200
+            Attributes = [] }
+      createProduct
+          7
+          "Rocking Chair"
+          100M
+          "/img/bg-img/8.jpg"
+          "/img/product-img/pro-big-8.jpg"
+          { Height = 9500
+            Length = 6500
+            Width = 5000
+            Weight = 5000
+            Attributes = [] }
+      createProduct
+          8
+          "Modern Chair"
+          50M
+          "/img/bg-img/1.jpg"
+          "/img/product-img/pro-big-1.jpg"
+          { Height = 8800
+            Length = 5800
+            Width = 3300
+            Weight = 1100
+            Attributes = [] }
+      createProduct
+          9
+          "Minimalistic Plant Pot - Discounted"
+          5M
+          "/img/bg-img/2.jpg"
+          "/img/product-img/pro-big-2.jpg"
+          { Height = 11500
+            Length = 4200
+            Width = 3800
+            Weight = 700
+            Attributes = [] }
+      createProduct
+          10
+          "Table Lamp"
+          30.50M
+          "/img/bg-img/10.jpg"
+          "/img/product-img/pro-big-10.jpg"
+          { Height = 6000
+            Length = 2000
+            Width = 2000
+            Weight = 300
+            Attributes = [] }
+      createProduct
+          11
+          "Expensive Dining Set"
+          1800.99M
+          "/img/bg-img/11.jpg"
+          "/img/product-img/pro-big-11.jpg"
+          { Height = 7800
+            Length = 11000
+            Width = 7000
+            Weight = 20000
+            Attributes = [] }
+      createProduct
+          12
+          "Plant Deco Set Wall"
+          2500M
+          "/img/bg-img/12.jpg"
+          "/img/product-img/pro-big-12.jpg"
+          { Height = 16000
+            Length = 8000
+            Width = 3000
+            Weight = 15000
+            Attributes = [] }
+      createProduct
+          13
+          "Punk Chair"
+          10.99M
+          "/img/bg-img/13.jpg"
+          "/img/product-img/pro-big-13.jpg"
+          { Height = 9200
+            Length = 5700
+            Width = 3700
+            Weight = 1100
+            Attributes = [] }
+      createProduct
+          14
+          "Huge Leather Sofa"
+          3999M
+          "/img/bg-img/14.jpg"
+          "/img/product-img/pro-big-14.jpg"
+          { Height = 8000
+            Length = 20000
+            Width = 10000
+            Weight = 100000
+            Attributes = [] }
+      createProduct
+          15
+          "Day Stand"
+          199M
+          "/img/bg-img/15.jpg"
+          "/img/product-img/pro-big-15.jpg"
+          { Height = 7000
+            Length = 9000
+            Width = 4000
+            Weight = 2200
+            Attributes = [] }
+      createProduct
+          16
+          "Cool Chair"
+          100M
+          "/img/bg-img/16.jpg"
+          "/img/product-img/pro-big-16.jpg"
+          { Height = 9400
+            Length = 6200
+            Width = 4200
+            Weight = 1600
+            Attributes = [] } ]
+
 
 module CompositionRoot =
     let compose (cfg: IConfigurationRoot) : CompositionRoot =

--- a/src/Gir/Decoders.fs
+++ b/src/Gir/Decoders.fs
@@ -9,13 +9,22 @@ let partnerAccessTokenDecoder =
 
 let purchaseTokenDecoder = Decode.field "jwt" Decode.string |> Decode.fromString
 
+let shippingParametersDecoder =
+    Decode.object (fun (get: Decode.IGetters) ->
+        { Height = get.Required.Field "height" Decode.int
+          Length = get.Required.Field "length" Decode.int
+          Width = get.Required.Field "width" Decode.int
+          Weight = get.Required.Field "weight" Decode.int
+          Attributes = get.Required.Field "attributes" (Decode.list Decode.string) })
+
 let productDecoder =
     Decode.object (fun (get: Decode.IGetters) ->
         { ProductId = get.Required.Field "productId" Decode.int
           Name = get.Required.Field "name" Decode.string
           Price = get.Required.Field "price" Decode.decimal
           Img = get.Required.Field "img" Decode.string
-          BigImg = get.Required.Field "bigImg" Decode.string })
+          BigImg = get.Required.Field "bigImg" Decode.string
+          ShippingParameters = get.Required.Field "shippingParameters" shippingParametersDecoder })
 
 let cartItemDecoder =
     Decode.object (fun (get: Decode.IGetters) ->
@@ -123,6 +132,11 @@ let aprWidgetSettingsDecoder: Decoder<AprWidgetSettings> =
 let sharedWidgetSettingsDecoder =
     Decode.object (fun (get: Decode.IGetters) -> { CustomStyles = get.Required.Field "customStyles" Decode.bool })
 
+let shippingSettingsDecoder =
+    Decode.object (fun (get: Decode.IGetters) ->
+        { IncludeShippingParameters = get.Required.Field "includeShippingParameters" Decode.bool
+          IncludeDefaultShippingItem = get.Required.Field "includeDefaultShippingItem" Decode.bool })
+
 let decodeSettings =
     Decode.object (fun (get: Decode.IGetters) ->
         { ExtraCheckoutFlags = get.Required.Field "extraCheckoutFlags" extraCheckoutFlagsDecoder
@@ -134,7 +148,8 @@ let decodeSettings =
           PaymentWidgetSettings = get.Required.Field "paymentWidgetSettings" paymentWidgetSettingsDecoder
           AdditionalFeatures = get.Required.Field "additionalFeatures" additionalFeaturesDecoder
           AprWidgetSettings = get.Required.Field "aprWidgetSettings" aprWidgetSettingsDecoder
-          SharedWidgetSettings = get.Required.Field "sharedWidgetCustomStyles" sharedWidgetSettingsDecoder })
+          SharedWidgetSettings = get.Required.Field "sharedWidgetCustomStyles" sharedWidgetSettingsDecoder
+          ShippingSettings = get.Required.Field "shippingSettings" shippingSettingsDecoder })
 
 let settingsDecoder (settingsString: string) =
     match Decode.fromString decodeSettings settingsString with

--- a/src/Gir/Domain.fs
+++ b/src/Gir/Domain.fs
@@ -1,16 +1,26 @@
 module Gir.Domain
 
+
+type ShippingParameters =
+    { Height: int
+      Length: int
+      Width: int
+      Weight: int
+      Attributes: string list }
+
 type Product =
     { ProductId: int
       Name: string
       Price: decimal
       Img: string
-      BigImg: string }
+      BigImg: string
+      ShippingParameters: ShippingParameters }
 
 type CheckoutItem =
     { Name: string
       Price: decimal
-      Quantity: int }
+      Quantity: int
+      ShippingParameters: ShippingParameters option }
 
 type CartEvent =
     | Add of productId: int * quantity: int
@@ -135,6 +145,10 @@ type AprWidgetSettings = { Enabled: bool }
 
 type SharedWidgetSettings = { CustomStyles: bool }
 
+type ShippingSettings =
+    { IncludeShippingParameters: bool
+      IncludeDefaultShippingItem: bool }
+
 type Settings =
     { ExtraCheckoutFlags: ExtraCheckoutFlags
       ExtraInitSettings: ExtraInitSettings
@@ -143,7 +157,8 @@ type Settings =
       PaymentWidgetSettings: PaymentWidgetSettings
       AdditionalFeatures: AdditionalFeatures
       AprWidgetSettings: AprWidgetSettings
-      SharedWidgetSettings: SharedWidgetSettings }
+      SharedWidgetSettings: SharedWidgetSettings
+      ShippingSettings: ShippingSettings }
 
 let languageToString =
     function
@@ -349,6 +364,10 @@ let defaultAdditionalFeatures: AdditionalFeatures =
 
 let defaultSharedWidgetSettings: SharedWidgetSettings = { CustomStyles = false }
 
+let defaultShippingSettings: ShippingSettings =
+    { IncludeShippingParameters = false
+      IncludeDefaultShippingItem = false }
+
 let defaultSettings: Settings =
     { ExtraCheckoutFlags = defaultExtraCheckoutFlags
       ExtraInitSettings = defaultExtraInitSettings
@@ -357,7 +376,8 @@ let defaultSettings: Settings =
       PaymentWidgetSettings = defaultPaymentWidgetSettings
       AdditionalFeatures = defaultAdditionalFeatures
       AprWidgetSettings = defaultAprWidgetSettings
-      SharedWidgetSettings = defaultSharedWidgetSettings }
+      SharedWidgetSettings = defaultSharedWidgetSettings
+      ShippingSettings = defaultShippingSettings }
 
 type ExtraIdentifiers = { OrderReference: string }
 
@@ -456,3 +476,7 @@ type PaymentStatus =
       Mode: string
       B2B: B2BData option
       B2C: B2CData option }
+
+type PurchaseIdentifiers =
+    { PurchaseToken: string
+      PurchaseId: string }

--- a/src/Gir/Products/Views.fs
+++ b/src/Gir/Products/Views.fs
@@ -771,6 +771,43 @@ let detailTemplate
                                                         []
                                                         [ str
                                                               "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquid quae eveniet culpa officia quidem mollitia impedit iste asperiores nisi reprehenderit consequatur, autem, nostrum pariatur enim?" ] ]
+                                              details
+                                                  [ _class "mb-5 mt-0" ]
+                                                  [ summary [] [ str "Shipping parameters" ]
+                                                    div
+                                                        [ _class "short_overview mb-0" ]
+                                                        [ p
+                                                              [ _class "mb-0" ]
+                                                              [ str
+                                                                <| sprintf
+                                                                    "Height: %imm"
+                                                                    product.ShippingParameters.Height ]
+                                                          p
+                                                              [ _class "mb-0" ]
+                                                              [ str
+                                                                <| sprintf
+                                                                    "Length: %imm"
+                                                                    product.ShippingParameters.Length ]
+                                                          p
+                                                              [ _class "mb-0" ]
+                                                              [ str
+                                                                <| sprintf
+                                                                    "Width: %imm"
+                                                                    product.ShippingParameters.Width ]
+                                                          p
+                                                              [ _class "mb-0" ]
+                                                              [ str
+                                                                <| sprintf
+                                                                    "Weight: %ig"
+                                                                    product.ShippingParameters.Weight ]
+                                                          p
+                                                              [ _class "mb-0" ]
+                                                              [ str
+                                                                <| sprintf
+                                                                    "Attributes: %s"
+                                                                    (String.concat
+                                                                        ";"
+                                                                        product.ShippingParameters.Attributes) ] ] ]
                                               form
                                                   [ _class "cart clearfix"
                                                     _method "post"

--- a/src/Gir/Settings/HttpHandlers.fs
+++ b/src/Gir/Settings/HttpHandlers.fs
@@ -79,7 +79,10 @@ let saveSettingsHandler (next: HttpFunc) (ctx: HttpContext) =
               PaymentWidgetSettings = { Enabled = checkboxValue "paymentWidgetEnabled" }
               AdditionalFeatures = { PartnerShippingEnabled = checkboxValue "partnerShippingEnabled" }
               AprWidgetSettings = { Enabled = checkboxValue "aprWidgetEnabled" }
-              SharedWidgetSettings = { CustomStyles = checkboxValue "sharedWidgetCustomStyles" } }
+              SharedWidgetSettings = { CustomStyles = checkboxValue "sharedWidgetCustomStyles" }
+              ShippingSettings =
+                { IncludeShippingParameters = checkboxValue "includeShippingParameters"
+                  IncludeDefaultShippingItem = checkboxValue "includeDefaultShippingItem" } }
 
         Session.setSettings ctx formData
         Session.deleteCartState ctx

--- a/src/Gir/Settings/Views.fs
+++ b/src/Gir/Settings/Views.fs
@@ -178,7 +178,8 @@ let template
           PaymentWidgetSettings = paymentWidgetSettings
           AdditionalFeatures = additionalFeatures
           AprWidgetSettings = aprWidgetSettings
-          SharedWidgetSettings = sharedWidgetSettings } =
+          SharedWidgetSettings = sharedWidgetSettings
+          ShippingSettings = shippingSettings } =
         settings
 
     let marketsOptions =
@@ -231,14 +232,18 @@ let template
                                 [ h1 [ _class "settings-heading" ] [ str "Settings Page" ]
                                   form
                                       [ _id "settings"; _action "/settings/save"; _method "POST" ]
-                                      [ div [] [ h3 [ _class "settings-heading" ] [ str "Market" ] ]
+                                      [ div
+                                            [ _class "settings-row" ]
+                                            [ h3 [ _class "settings-heading" ] [ str "Market" ] ]
                                         selectView
                                             "market"
                                             "Market"
                                             marketsOptions
                                             (marketToString settings.Market)
                                             true
-                                        div [] [ h3 [ _class "settings-heading" ] [ str "Extra Identifiers" ] ]
+                                        div
+                                            [ _class "settings-row" ]
+                                            [ h3 [ _class "settings-heading" ] [ str "Extra Identifiers" ] ]
                                         textInput
                                             "orderReference"
                                             "Order Reference"
@@ -246,7 +251,9 @@ let template
                                             settings.OrderReference
                                             true
                                             None
-                                        div [] [ h3 [ _class "settings-heading" ] [ str "Extra Init Options" ] ]
+                                        div
+                                            [ _class "settings-row" ]
+                                            [ h3 [ _class "settings-heading" ] [ str "Extra Init Options" ] ]
                                         selectView
                                             "language"
                                             "Language"
@@ -365,7 +372,9 @@ let template
                                             None
                                             initSettings.SkipEmailZipEntry
                                             true
-                                        div [] [ h3 [ _class "settings-heading" ] [ str "Extra Checkout Flags" ] ]
+                                        div
+                                            [ _class "settings-row" ]
+                                            [ h3 [ _class "settings-heading" ] [ str "Extra Checkout Flags" ] ]
                                         checkboxView "disableFocus" "Disable Focus" None checkoutFlags.DisableFocus true
                                         checkboxView
                                             "beforeSubmitCallbackEnabled"
@@ -422,7 +431,9 @@ let template
                                                 "Make sure you enable either SMS or Email newsletter checkbox in order to display extra t&c")
                                             checkoutFlags.Extras.ExtraTermsAndConditions
                                             true
-                                        div [] [ h3 [ _class "settings-heading" ] [ str "Payment and APR Widget" ] ]
+                                        div
+                                            [ _class "settings-row" ]
+                                            [ h3 [ _class "settings-heading" ] [ str "Payment and APR Widget" ] ]
                                         checkboxView
                                             "paymentWidgetEnabled"
                                             "Enable Payment Widget"
@@ -441,7 +452,9 @@ let template
                                             None
                                             sharedWidgetSettings.CustomStyles
                                             (isPaymentWidgetEnabledGlobally paymentWidgetBundleUrl)
-                                        div [] [ h3 [ _class "settings-heading" ] [ str "Additional Features" ] ]
+                                        div
+                                            [ _class "settings-row" ]
+                                            [ h3 [ _class "settings-heading" ] [ str "Additional Features" ] ]
                                         checkboxView
                                             "partnerShippingEnabled"
                                             "Enable Partner Shipping Module"
@@ -449,6 +462,18 @@ let template
                                                 "`partnerShippingBundleUrl` has to be provided and shipping module has to be setup on current partner in order to be used")
                                             additionalFeatures.PartnerShippingEnabled
                                             (String.IsNullOrEmpty partnerShippingBundleUrl |> not)
+                                        checkboxView
+                                            "includeShippingParameters"
+                                            "Include shipping parameters in init payment"
+                                            None
+                                            shippingSettings.IncludeShippingParameters
+                                            true
+                                        checkboxView
+                                            "includeDefaultShippingItem"
+                                            "Include default shipping item in init payment"
+                                            None
+                                            shippingSettings.IncludeDefaultShippingItem
+                                            true
                                         div
                                             [ _style
                                                   "display: flex; flex: 1; flex-wrap: wrap; flex-direction: row; align-items: center; justify-content: space-between; padding: 20px 10px;" ]

--- a/src/Gir/Test/Views.fs
+++ b/src/Gir/Test/Views.fs
@@ -6,7 +6,10 @@ open Gir.Layout
 
 let template (checkoutFrontendBundleUrl: string) (purchaseToken: string) =
     div
-        [ _id "checkout-form"; _style "padding: 20px;" ]
+        [ _id "checkout-form"
+          _style "padding: 20px;"
+          _data "purchaseToken" purchaseToken ]
+
         [ script [ _type "application/javascript"; _src "/js/checkout-integration-simple.js" ] []
           script
               [ _type "application/javascript" ]

--- a/src/Gir/WebRoot/css/main.css
+++ b/src/Gir/WebRoot/css/main.css
@@ -76,8 +76,8 @@ details:not([open])>div {
 }
 
 .settings-heading {
-  padding-left: 10px;
-  padding-right: 10px;
+  padding: 0.5rem 10px 0.5rem 0;
+  margin-bottom: 0;
 }
 
 .settings-row {


### PR DESCRIPTION
Add ability to include ShippingParameters in init payment
Add ability to include default ShippingItem in init payment

Add ShippingParameters to all items, display it under <details> element

Add data attribute to checkout root element with purchaseToken and purchaseId (if available) for easier debugging and testing - quick access to purchase id for log analysis

- minor - make settings headers fit more into the page