### PR TITLE
B31974: Gaps in Checkout form

### DIFF
--- a/src/Gir/WebRoot/css/main.css
+++ b/src/Gir/WebRoot/css/main.css
@@ -121,3 +121,7 @@ details:not([open])>div {
 .settings-view input[type="text"] {
   width: 100%;
 }
+
+label {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Had to create global css rule, saying labels have no margin bottom. This fixes it. Checked the app, have not found any issues with label anywhere.